### PR TITLE
荣耀判断逻辑优化

### DIFF
--- a/library/src/main/java/com/github/gzuliyujiang/oaid/OAIDRom.java
+++ b/library/src/main/java/com/github/gzuliyujiang/oaid/OAIDRom.java
@@ -48,7 +48,7 @@ public final class OAIDRom {
     }
 
     public static boolean isHuawei() {
-        // 华为手机、荣耀手机
+        // 华为手机，以及仍使用华为厂商字段的老荣耀机型
         return Build.MANUFACTURER.equalsIgnoreCase("HUAWEI") ||
                 Build.BRAND.equalsIgnoreCase("HUAWEI");
     }

--- a/library/src/main/java/com/github/gzuliyujiang/oaid/OAIDRom.java
+++ b/library/src/main/java/com/github/gzuliyujiang/oaid/OAIDRom.java
@@ -55,7 +55,8 @@ public final class OAIDRom {
 
     public static boolean isHonor() {
         // 荣耀手机
-        return Build.BRAND.equalsIgnoreCase("HONOR");
+        return Build.MANUFACTURER.equalsIgnoreCase("HONOR") ||
+                Build.BRAND.equalsIgnoreCase("HONOR");
     }
 
     public static boolean isHarmonyOS() {

--- a/library/src/main/java/com/github/gzuliyujiang/oaid/impl/OAIDFactory.java
+++ b/library/src/main/java/com/github/gzuliyujiang/oaid/impl/OAIDFactory.java
@@ -91,7 +91,7 @@ public final class OAIDFactory {
         if (OAIDRom.isASUS()) {
             return new AsusImpl(context);
         }
-        if (OAIDRom.isHonor() && !OAIDRom.isEmui()) {
+        if (OAIDRom.isHonor() && OAIDRom.isEmui()) {
             HonorImpl honor = new HonorImpl(context);
             if (honor.supported()) {
                 // 支持的话（Magic UI 4.0,5.0,6.0及MagicOS 7.0或以上）直接使用荣耀的实现，否则尝试华为的实现

--- a/library/src/main/java/com/github/gzuliyujiang/oaid/impl/OAIDFactory.java
+++ b/library/src/main/java/com/github/gzuliyujiang/oaid/impl/OAIDFactory.java
@@ -91,10 +91,10 @@ public final class OAIDFactory {
         if (OAIDRom.isASUS()) {
             return new AsusImpl(context);
         }
-        if (OAIDRom.isHonor() && OAIDRom.isEmui()) {
+        if (OAIDRom.isHonor()) {
             HonorImpl honor = new HonorImpl(context);
             if (honor.supported()) {
-                // 支持的话（Magic UI 4.0,5.0,6.0及MagicOS 7.0或以上）直接使用荣耀的实现，否则尝试华为的实现
+                // 部分荣耀机型仍然会暴露 EMUI 属性，这里以荣耀服务是否可用作为优先判断依据。
                 return honor;
             }
         }

--- a/library/src/main/java/com/github/gzuliyujiang/oaid/impl/OAIDFactory.java
+++ b/library/src/main/java/com/github/gzuliyujiang/oaid/impl/OAIDFactory.java
@@ -91,10 +91,10 @@ public final class OAIDFactory {
         if (OAIDRom.isASUS()) {
             return new AsusImpl(context);
         }
-        if (OAIDRom.isHonor()) {
+        if (OAIDRom.isHonor() && !OAIDRom.isHuawei()) {
             HonorImpl honor = new HonorImpl(context);
             if (honor.supported()) {
-                // 部分荣耀机型仍然会暴露 EMUI 属性，这里以荣耀服务是否可用作为优先判断依据。
+                // 新荣耀机型可能同时暴露 EMUI/MagicUI 属性，这里先以华为厂商字段区分老荣耀，再尝试荣耀实现。
                 return honor;
             }
         }


### PR DESCRIPTION
1.荣耀机上 isEmui() 依旧可能为真 
核心改动是：荣耀机型不再用 isEmui() 当分流条件，而是只要识别到荣耀，就先尝试 HonorImpl.supported()；只有荣耀服务不可用时，才回退到华为实现。这样即使荣耀手机同时命中 isEmui() 和 isMagicUI()，也不会先被归到华为链路里，荣耀识别补强成同时检查 Build.MANUFACTURER 和 Build.BRAND，避免只看 BRAND 漏判